### PR TITLE
Increase php required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "~5.5.0|~5.6.0|>=7.0.0 <7.3.0"
+        "php": "~5.5.0|~5.6.0|>=7.0.0 <7.4.0"
     },
     "autoload": {
         "psr-4": { "OnePica\\AvaTax16\\": "src/OnePica/AvaTax16/" }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0"
+        "php": "~5.5.0|~5.6.0|>=7.0.0 <7.3.0"
     },
     "autoload": {
         "psr-4": { "OnePica\\AvaTax16\\": "src/OnePica/AvaTax16/" }


### PR DESCRIPTION
This PR will:

- allow composer to install this library even when newer (and supported 😉 ) PHP versions are being used.

Testing - 

```
git:master avatax16-lib Ω ~/.composer/vendor/bin/phpcs -p . --standard=PHPCompatibility --runtime-set testVersion 7.2
........................................... 43 / 43 (100%)


Time: 384ms; Memory: 12Mb

git:master avatax16-lib Ω ~/.composer/vendor/bin/phpcs -p . --standard=PHPCompatibility --runtime-set testVersion 7.1
........................................... 43 / 43 (100%)
```